### PR TITLE
Add readme paths in kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -3,6 +3,7 @@ multi:
         summary: Hoverboard breakout board for Bobbycars
         gerbers: bobbycar_breakout/gerber
         bom: bobbycar_breakout/BOM.csv
+        readme: bobbycar_breakout/README.md
         site: https://github.com/NiklasFauth/hoverboard-firmware-hack
         eda:
             type: kicad
@@ -11,6 +12,7 @@ multi:
         summary: Nunchuk to hoverboard connector board
         gerbers: nunchuk_breakout/gerber/single
         bom: nunchuk_breakout/BOM.csv
+        readme: nunchuk_breakout/README.md
         site: https://github.com/NiklasFauth/hoverboard-firmware-hack
         eda:
             type: kicad
@@ -19,6 +21,7 @@ multi:
         summary: Nunchuk to hoverboard connector board panel
         gerbers: nunchuk_breakout/gerber/panel/Nunchuk_breakout
         bom: nunchuk_breakout/BOM.csv
+        readme: nunchuk_breakout/README.md
         site: https://github.com/NiklasFauth/hoverboard-firmware-hack
         eda:
             type: kicad


### PR DESCRIPTION
Hi, it's Abdulrahman from Kitspace.org :wave: 

We are very close to the alpha release of [kitspace-v2](https://github.com/kitspace/kitspace-v2).
While testing, we noticed that `hoverboard-breakout` projects, could have better READMEs just by adding the paths in `kitspace.yaml`.

Currently, all projects have the [repo README](https://github.com/Jana-Marie/hoverboard-breakout/blob/master/README.md), instead of the project-specific README. This PR adds `readme` paths to all projects. Here is how the README would look on kitspace for the `bobbycar_breakout` project after merging,
|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/37152329/219306173-abdc638a-6f85-4141-a368-913e868ee694.png)|![image](https://user-images.githubusercontent.com/37152329/219306290-197e3913-d6b2-4ea4-a60a-77948e1c9505.png)|

Could you please review these changes and accept them if they are convenient?
